### PR TITLE
Update the Mandrill API key

### DIFF
--- a/addAlias.js
+++ b/addAlias.js
@@ -13,17 +13,14 @@
 (function (){
     "use strict";
     var MongoClient     = require("mongodb").MongoClient,
-        Handlebars      = require("handlebars"),
         templates       = require("./templates"),
         _               = require("lodash"),
         Getopt          = require("node-getopt"),
         async           = require("async"),
-        Mandrill        = require('mandrill-api/mandrill').Mandrill,
         fs              = require("fs"),
         createSlug      = require("./slugger"),
         timestamp       = require("./timestamp"),
 
-        mandrillClient  = new Mandrill('16rUK74RBFiacFNfmu_2sA'),
         getopt          = new Getopt([
             [ "n", "name=ARG",  "Name of the boss"],
             [ "a", "alias=ARG", "New Alias"],
@@ -50,7 +47,7 @@
         process.exit(rc);
     }
 
-    function getOptions(args) {
+    function getOptions() {
         var input           = getopt.parse(cliArgs),
             options         = input.options,
             messages = [];
@@ -142,7 +139,7 @@
                         }
                         if(results.internalEmailInUse) {
                             console.log("Creating alias");
-                            createAlias(bossColl, options.name, options.alias, function (err, result) {
+                            createAlias(bossColl, options.name, options.alias, function (err) {
                                 if (err) {
                                     errorOut("Could not create boss: ", err);
                                 }

--- a/addBoss.js
+++ b/addBoss.js
@@ -26,7 +26,7 @@
         createSlug      = require("./slugger"),
         timestamp       = require("./timestamp"),
         
-        mandrillClient  = new Mandrill('16rUK74RBFiacFNfmu_2sA'),
+        mandrillClient  = new Mandrill('nvspEmFm9L67h97o_-covg'),
         getopt          = new Getopt([
                             [ "n", "name=ARG",  "Name of the boss"],
                             [ "e", "email=ARG", "External email address"],
@@ -184,7 +184,7 @@
                 }]
             };
 
-        cities.insert(city, function(err, result) {
+        cities.insert(city, function(err) {
             if(err) {
                 callback(err);
             }
@@ -289,11 +289,11 @@
                     if(results.externalEmailInUse && !options.reuseBoss) {
                         errorOut("'"+options.email+"' is already a target email");
                     }
-                    newBoss = createBoss(bosses, options.name, options.email, options.reuseBoss, function(err, result) {
+                    newBoss = createBoss(bosses, options.name, options.email, options.reuseBoss, function(err) {
                         if(err) {
                             errorOut("Could not create boss: ", err);
                         }
-                        var callback = function (err, result) {
+                        var callback = function (err) {
                             if(err) {
                                 errorOut("Failed to update/create city: ", err);
                             }

--- a/reportBosses.js
+++ b/reportBosses.js
@@ -14,7 +14,7 @@
 
         mongoHost       = process.env.MONGO_HOST,
 
-        mandrillClient  = new Mandrill('16rUK74RBFiacFNfmu_2sA');
+      mandrillClient  = new Mandrill('nvspEmFm9L67h97o_-covg');
 
     if(!mongoHost) {
         console.error("No MONGO_HOST set");

--- a/reportCityBosses.js
+++ b/reportCityBosses.js
@@ -14,7 +14,7 @@
 
         mongoHost       = process.env.MONGO_HOST,
 
-        mandrillClient  = new Mandrill('16rUK74RBFiacFNfmu_2sA');
+      mandrillClient  = new Mandrill('nvspEmFm9L67h97o_-covg');
 
     if(!mongoHost) {
         console.error("No MONGO_HOST set");


### PR DESCRIPTION
The old Mandrill API key had expired, resulting in emails getting rejected. This new key has been tested via the Node REPL and looks to be working correctly.

It is limited to 2000 emails, but that should keep us going for a little while.

Tagging @llanford for awareness, but I'm gonna merge this
